### PR TITLE
Return default value when an exception is thrown while unprotecting data

### DIFF
--- a/src/Synercoding.FormsAuthentication/FormsAuthenticationDataFormat.cs
+++ b/src/Synercoding.FormsAuthentication/FormsAuthenticationDataFormat.cs
@@ -35,8 +35,15 @@ namespace Synercoding.FormsAuthentication
 
         public TData Unprotect(string protectedText, string purpose)
         {
-            var cookie = _cryptor.Unprotect(protectedText);
-            return _convertFrom(cookie);
+            try
+            {
+                var cookie = _cryptor.Unprotect(protectedText);
+                return _convertFrom(cookie);
+            }
+            catch
+            {
+                return default(TData);
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #2 

I decided not to add a property to `FormsAuthenticationOptions` to handle the exception as I suppose every exception that will be thrown won't give many details about what went wrong.

Let me know what you think.