### PR TITLE
Add version in FormsAuthenticationCookie

### DIFF
--- a/src/Synercoding.FormsAuthentication/FormsAuthenticationCookie.cs
+++ b/src/Synercoding.FormsAuthentication/FormsAuthenticationCookie.cs
@@ -4,6 +4,7 @@ namespace Synercoding.FormsAuthentication
 {
     public class FormsAuthenticationCookie
     {
+		public byte Version { get; set; }
         public DateTime IssuedUtc { get; set; }
         public DateTime ExpiresUtc { get; set; }
         public bool IsPersistent { get; set; }

--- a/src/Synercoding.FormsAuthentication/FormsAuthenticationCryptor.cs
+++ b/src/Synercoding.FormsAuthentication/FormsAuthenticationCryptor.cs
@@ -56,7 +56,7 @@ namespace Synercoding.FormsAuthentication
             using (var ticketWriter = new SerializingBinaryWriter(ticketBlobStream))
             {
                 ticketWriter.Write((byte)1);
-                ticketWriter.Write((byte)1);
+                ticketWriter.Write(data.Version);
                 ticketWriter.Write(data.IssuedUtc.Ticks);
                 ticketWriter.Write((byte)0xfe);
                 ticketWriter.Write(data.ExpiresUtc.Ticks);
@@ -82,7 +82,7 @@ namespace Synercoding.FormsAuthentication
                 if (serializedFormatVersion != 0x01)
                     throw new ArgumentException("The data is not in the correct format, first byte must be 0x01.", nameof(data));
 
-                int ticketVersion = ticketReader.ReadByte();
+                byte ticketVersion = ticketReader.ReadByte();
 
                 DateTime ticketIssueDateUtc = new DateTime(ticketReader.ReadInt64(), DateTimeKind.Utc);
 
@@ -103,7 +103,8 @@ namespace Synercoding.FormsAuthentication
                 //create ticket
                 return new FormsAuthenticationCookie()
                 {
-                    UserName = ticketName,
+					Version = ticketVersion,
+					UserName = ticketName,
                     UserData = ticketUserData,
                     CookiePath = ticketCookiePath,
                     IsPersistent = ticketIsPersistent,

--- a/src/Synercoding.FormsAuthentication/FormsAuthenticationCryptor.cs
+++ b/src/Synercoding.FormsAuthentication/FormsAuthenticationCryptor.cs
@@ -103,8 +103,8 @@ namespace Synercoding.FormsAuthentication
                 //create ticket
                 return new FormsAuthenticationCookie()
                 {
-					Version = ticketVersion,
-					UserName = ticketName,
+                    Version = ticketVersion,
+                    UserName = ticketName,
                     UserData = ticketUserData,
                     CookiePath = ticketCookiePath,
                     IsPersistent = ticketIsPersistent,


### PR DESCRIPTION
Fixes #12 

I left the default to 0. I don't think the actual value really matters. In any case, it will remain compatible with Cookies/ticket generated by ASP.Net 4.5 and for people actually using it, they will specify a value when creating the FormsAuthenticationCookie.